### PR TITLE
Fix documentation typo - function components introduction.mdx

### DIFF
--- a/website/versioned_docs/version-0.20/concepts/function-components/introduction.mdx
+++ b/website/versioned_docs/version-0.20/concepts/function-components/introduction.mdx
@@ -61,7 +61,7 @@ For the previous example this would look like this:
 <App>
   <HelloWorld>
     <p>"Hello world"</p>
-  </HelloWord>
+  </HelloWorld>
 </App>
 ```
 


### PR DESCRIPTION
#### Description

Just add a missing 'l' to the closing HelloWorld tag in the function components documentation (introduction.mdx)

#### Checklist

- [x] I have reviewed my own code
- [ ] I have added tests

